### PR TITLE
Retry UDP request on timeout before giving up

### DIFF
--- a/servers.php
+++ b/servers.php
@@ -932,7 +932,8 @@ for ($clientport = CLIENT_PORT; $clientport < CLIENT_PORT + CLIENT_PORTS_TO_TRY;
 	}
 }
 
-socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec'=>1, 'usec'=>500000));
+$timeout_ms = 500;
+socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec'=>0, 'usec'=>$timeout_ms * 1000));
 
 $name = isset($_GET['name']) ? $_GET['name'] : $host;
 
@@ -957,18 +958,39 @@ $fromport = $port;
 // $maxgap = 0;
 // $last = gettimeofday(true);
 
-while (!$done && $n = socket_recvfrom($sock, $data, 32767, 0, $fromip, $fromport)) {
-	// printf("socket_recvfrom: %d bytes received from %s:%d\n", $n, $fromip, $fromport);
+$attempts = 1;
+$max_attempts = 3;
 
-	if ($n != strlen($data)) {
-		error_log("Returned data length does not match string from $fromip:$fromport");
-		continue;
+while (!$done) {
+	$n = socket_recvfrom($sock, $data, 32767, 0, $fromip, $fromport);
+
+	if ($n === false) {
+		if (count($servers) <= 1 && $attempts < $max_attempts) {
+			// Timeout with no data yet — re-send and try again
+			$attempts++;
+			if (isset($_GET['directory'])) {
+				send_request($sock, CLM_REQ_SERVER_LIST, $ip, $port);
+			} else {
+				send_ping_with_num_clients($sock, $ip, $port);
+			}
+			continue;
+		} elseif (count($servers) <= 1) {
+			error_log("servers.php: no response from $ip after $max_attempts attempts");
+			break;
+		} else {
+			break; // normal end-of-stream
+		}
 	}
 
 	// $now = gettimeofday(true);
 
 	// if ($now - $last > $maxgap) $maxgap = $now - $last;
 	// $last = $now;
+
+	if ($n != strlen($data)) {
+		error_log("Returned data length does not match string from $fromip:$fromport");
+		continue;
+	}
 
 	process_received($sock, $data, $n, $fromip, $fromport);
 }


### PR DESCRIPTION
## Summary

- Replaces the single 1.5s `SO_RCVTIMEO` with a 500ms timeout and up to 3 attempts
- On timeout with no data received, the same request is re-fired and `recvfrom` waits again
- Worst-case total wait time is unchanged (~1.5s), but a single dropped UDP packet is recovered automatically
- Logs an error only on total failure (all attempts exhausted with no response)

## Motivation

UDP is inherently lossy. The original code made one attempt and either succeeded or silently returned nothing to the client. Under any packet loss — even transient — the directory or server query would fail completely. The retry loop makes the behaviour consistent with what users expect from a web page fetching live server lists.

## Test plan

- Verified baseline RTT to `anygenre1.jamulus.io:22124` is ~142ms, well within the 500ms window
- Applied `iptables` 40% random UDP drop rule and ran 20 requests: attempt-2 recoveries worked correctly, attempt-3 recoveries worked correctly, total-failure rate matched expected `p³` probability
- Removed drop rule and confirmed normal operation restored