### PR TITLE
Fix PHP warning: Undefined array key 7 in version sort logic

### DIFF
--- a/servers.php
+++ b/servers.php
@@ -711,7 +711,7 @@ function process_received($sock, $data, $n, $fromip, $fromport) {
 				} elseif (strncmp($m[5], 'rc', 2)==0 || strncmp($m[5], 'beta', 4)==0 || strncmp($m[5], 'alpha', 5)==0) {
 					// release candidate, beta or alpha - sort before bare version
 					$k = '<';
-				} elseif ($m[7] == '') {
+				} elseif (!isset($m[7]) || $m[7] == '') {
 					// no timestamp - sort after bare version but before timestamps
 					$k = '>';
 				} else {
@@ -903,7 +903,7 @@ function process_received($sock, $data, $n, $fromip, $fromport) {
 				} elseif (strncmp($m[5], 'rc', 2)==0 || strncmp($m[5], 'beta', 4)==0 || strncmp($m[5], 'alpha', 5)==0) {
 					// release candidate, beta or alpha - sort before bare version
 					$k = '<';
-				} elseif ($m[7] == '') {
+				} elseif (!isset($m[7]) || $m[7] == '') {
 					// no timestamp - sort after bare version but before timestamps
 					$k = '>';
 				} else {


### PR DESCRIPTION
## Problem

The nginx/PHP-FPM error log was flooded with repeated warnings:

```
PHP Warning: Undefined array key 7 in servers.php on line 719
PHP Warning: Undefined array key 7 in servers.php on line 906
```

These appear in two places where `servers.php` parses version strings using this regex:

```php
preg_match('/((\d+)\.(\d+)\.(\d+)([^:]*))(:(.*))?/', $a['version'], $m)
```

The trailing group `(:(.*))?` is optional — it captures a colon-separated timestamp suffix. When the version string has no such suffix (e.g. a pre-release like `1.2.3-somevariant`), PHP's `preg_match` does not populate `$m[6]` or `$m[7]` in the match array at all. Directly comparing `$m[7] == ''` then triggers an "Undefined array key" warning on every request.

## Fix

Guard the access with `isset()` so that a missing capture group is treated the same as an empty one:

```php
} elseif (!isset($m[7]) || $m[7] == '') {
```

This matches the existing intent of the code (treat no timestamp the same as an empty timestamp) while suppressing the spurious warning.