### PR TITLE
Fix premature loop exit on unexpected connected-mode messages

### DIFF
--- a/servers.php
+++ b/servers.php
@@ -687,10 +687,10 @@ function process_received($sock, $data, $n, $fromip, $fromport) {
 			$a = unpack("a{$len}welcome", substr($data, $i, $len)); $i += $len;
 			$server['welcome'] = $a['welcome'];
 			unset($server);
+			$done = true;	// received the welcome message
 		} else {
 			error_log("Unexpected CHAT_TEXT from $fromip:$fromport");
 		}
-		$done = true;	// received the welcome message
 
 		break;
 
@@ -721,10 +721,10 @@ function process_received($sock, $data, $n, $fromip, $fromport) {
 				$server['versionsort'] = sprintf("%03d%03d%03d%s%s", $m[2], $m[3], $m[4], $k, $m[5]);
 			}
 			unset($server);
+			$done = true;	// always comes after welcome message
 		} else {
 			error_log("Unexpected VERSION_AND_OS from $fromip:$fromport\n");
 		}
-		$done = true;	// always comes after welcome message
 
 		break;
 
@@ -735,10 +735,10 @@ function process_received($sock, $data, $n, $fromip, $fromport) {
 			$resp = unpack("Crecstate", substr($data, 7, 1));
 			$server['recstate'] = $resp['recstate'];
 			unset($server);
+			$done = true;	// always comes after welcome message
 		} else {
 			error_log("Unexpected RECORDER_STATE from $fromip:$fromport");
 		}
-		$done = true;	// always comes after welcome message
 
 		break;
 


### PR DESCRIPTION
## Summary

- `CHAT_TEXT`, `VERSION_AND_OS`, and `RECORDER_STATE` all set `$done = true` unconditionally, outside the `if/else` that checks whether the packet came from a known server
- A stray or unexpected packet of any of these types from an unrecognized source would silently terminate the receive loop early, truncating results with no indication to the caller
- Fix moves `$done = true` inside the known-source branch in all three cases

## Test plan

- [ ] `?server=` mode: verify normal connected-mode message flow still sets `$done` and exits correctly
- [ ] `?query=` mode: same
- [ ] Confirm that an unexpected-source log message no longer also exits the loop