### PR TITLE
Fix UDP retry condition: use $received_data flag instead of count($servers)

### DIFF
--- a/servers.php
+++ b/servers.php
@@ -932,7 +932,8 @@ for ($clientport = CLIENT_PORT; $clientport < CLIENT_PORT + CLIENT_PORTS_TO_TRY;
 	}
 }
 
-socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec'=>1, 'usec'=>500000));
+$timeout_ms = 500;
+socket_set_option($sock, SOL_SOCKET, SO_RCVTIMEO, array('sec'=>0, 'usec'=>$timeout_ms * 1000));
 
 $name = isset($_GET['name']) ? $_GET['name'] : $host;
 
@@ -957,18 +958,39 @@ $fromport = $port;
 // $maxgap = 0;
 // $last = gettimeofday(true);
 
-while (!$done && $n = socket_recvfrom($sock, $data, 32767, 0, $fromip, $fromport)) {
-	// printf("socket_recvfrom: %d bytes received from %s:%d\n", $n, $fromip, $fromport);
+$attempts = 1;
+$max_attempts = 3;
 
-	if ($n != strlen($data)) {
-		error_log("Returned data length does not match string from $fromip:$fromport");
-		continue;
+while (!$done) {
+	$n = socket_recvfrom($sock, $data, 32767, 0, $fromip, $fromport);
+
+	if ($n === false) {
+		if (count($servers) <= 1 && $attempts < $max_attempts) {
+			// Timeout with no data yet — re-send and try again
+			$attempts++;
+			if (isset($_GET['directory'])) {
+				send_request($sock, CLM_REQ_SERVER_LIST, $ip, $port);
+			} else {
+				send_ping_with_num_clients($sock, $ip, $port);
+			}
+			continue;
+		} elseif (count($servers) <= 1) {
+			error_log("servers.php: no response from $ip after $max_attempts attempts");
+			break;
+		} else {
+			break; // normal end-of-stream
+		}
 	}
 
 	// $now = gettimeofday(true);
 
 	// if ($now - $last > $maxgap) $maxgap = $now - $last;
 	// $last = $now;
+
+	if ($n != strlen($data)) {
+		error_log("Returned data length does not match string from $fromip:$fromport");
+		continue;
+	}
 
 	process_received($sock, $data, $n, $fromip, $fromport);
 }

--- a/servers.php
+++ b/servers.php
@@ -960,12 +960,13 @@ $fromport = $port;
 
 $attempts = 1;
 $max_attempts = 3;
+$received_data = false;
 
 while (!$done) {
 	$n = socket_recvfrom($sock, $data, 32767, 0, $fromip, $fromport);
 
 	if ($n === false) {
-		if (count($servers) <= 1 && $attempts < $max_attempts) {
+		if (!$received_data && $attempts < $max_attempts) {
 			// Timeout with no data yet — re-send and try again
 			$attempts++;
 			if (isset($_GET['directory'])) {
@@ -974,7 +975,7 @@ while (!$done) {
 				send_ping_with_num_clients($sock, $ip, $port);
 			}
 			continue;
-		} elseif (count($servers) <= 1) {
+		} elseif (!$received_data) {
 			error_log("servers.php: no response from $ip after $max_attempts attempts");
 			break;
 		} else {
@@ -992,6 +993,7 @@ while (!$done) {
 		continue;
 	}
 
+	$received_data = true;
 	process_received($sock, $data, $n, $fromip, $fromport);
 }
 


### PR DESCRIPTION
## Summary

- Replaces `count($servers) <= 1` retry guard with an explicit `$received_data` boolean flag
- Retry now triggers only when zero bytes were received before the timeout — not based on how many servers are in the list

## Problem with the count($servers) approach

The `count($servers) <= 1` heuristic conflates two different things:

- For `?query` and `?server` requests, `$servers` is pre-populated with 1 entry (the target server), so `<= 1` correctly means "no response data received yet."
- For `?directory` requests, `$servers` starts at 0 and grows as `CLM_SERVER_LIST` packets arrive. A directory server that legitimately has only one registered server will receive its full response, hit the trailing timeout, and still satisfy `count($servers) <= 1` — triggering an unnecessary retry and adding ~500ms latency.

Production logs confirm this is not hypothetical. Several real directory endpoints regularly return exactly one server:

```
jazz.jamulus.io:22224     servers=1
jazz.jamulus.io:22624     servers=1
rock.jamulus.io:22624     servers=1
classical.jamulus.io:22224 servers=1
classical.jamulus.io:22624 servers=1
```

## Fix

An explicit `$received_data` flag is set to `true` on the first successfully received packet, before `process_received()` is called. The retry and failure conditions check `!$received_data` instead of `count($servers) <= 1`.

This cleanly separates "did we receive anything?" from "how many servers were listed?"

## Relationship to PR #7

This is a corrected version of the retry logic introduced in #7. The motivation and overall structure are the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)